### PR TITLE
Add serial monitor tools (arduino-cli monitor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Environment variables override defaults:
 | LOG_LEVEL            | `INFO`                                              |
 | OPENAI_API_KEY       | your OpenAI API key (required for AI‑powered WireViz)|
 | OPENROUTER_API_KEY   | optional alternative to `OPENAI_API_KEY`            |
+| ARDUINO_SERIAL_LOG_MAX_BYTES | max size per serial log file (bytes; 0 disables) |
+| ARDUINO_SERIAL_LOG_ROTATE_COUNT | number of rotated serial logs to keep      |
 
 ## Quick Start
 
@@ -67,6 +69,12 @@ Server listens on STDIO for JSON-RPC MCP calls. Key methods:
 ### Boards
 - `list_boards()`
 - `board_search(query)`
+
+### Serial Monitor
+- `serial_monitor_start(port, baud, buffer_lines, log_to_file, ...)`
+- `serial_monitor_read(monitor_id, lines)`
+- `serial_monitor_list()`
+- `serial_monitor_stop(monitor_id)`
 
 ### File Ops
 - `rename_file(src, dest)`
@@ -104,4 +112,3 @@ To integrate with MCP clients (e.g., Claude Desktop), set your OpenAI API key in
 ## License
 
 MIT
-


### PR DESCRIPTION
## Overview
This PR adds a serial monitor feature set on top of `arduino-cli monitor`, exposed via MCP tools. It includes a bounded in‑memory ring buffer, optional log file with rotation, and safe pause/resume behavior during uploads. Implementation uses a dedicated reader thread (cross‑platform) to keep the MCP event loop responsive.

## New Tools
- `serial_monitor_start(port, baud=115200, buffer_lines=2000, log_to_file=True, log_file="", board_fqbn="", protocol="", auto_reconnect=True, log_max_bytes=..., log_rotate_count=...)`
  - Starts a monitor and returns a monitor id.
  - `log_file` (optional) must be under user home; defaults to `~/Documents/Arduino_MCP_Sketches/_serial_logs/PORT_TIMESTAMP.log`.
- `serial_monitor_read(monitor_id, lines=200)`
  - Returns latest lines from the ring buffer.
- `serial_monitor_list()`
  - Lists all monitors with status, buffer size, and log info.
- `serial_monitor_stop(monitor_id, force=True, wait_tasks=False)`
  - Stops and releases the port (fast stop by default).

## Behavior Details
- **Ring buffer**: bounded deque (`buffer_lines`), stores last lines only.
- **Optional logging**: text log with rotation.
  - Env overrides: `ARDUINO_SERIAL_LOG_MAX_BYTES`, `ARDUINO_SERIAL_LOG_ROTATE_COUNT`.
- **Upload interaction**: `upload_sketch` pauses any monitor on the same port before upload, then resumes it after success. If none were running and `monitor_after_upload=True`, a new monitor is started.
- **Auto‑reconnect**: user’s original `auto_reconnect` preference is restored after pause/resume.

## Implementation Notes
- Uses `subprocess.Popen` + a dedicated reader thread to avoid asyncio/subprocess pipe starvation on Windows (seen as tool call timeouts under continuous stdout). This path is used cross‑platform for consistency and simplicity.
- Uses `arduino-cli monitor --quiet --no-color` for clean output.

## Documentation Updates
- README now lists serial monitor tools and log‑rotation env vars.

## Testing
- Windows 11: start/read/list/stop in a loop while monitor runs (no timeouts).
- Upload with active monitor: monitor pauses then resumes after upload.

Fixes/relates to: #1